### PR TITLE
Prevent ambiguous output, replace `disambiguatePaths` option with `flat` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Add configuration under the `contractSizer` key:
 |-|-|-|
 | `alphaSort` | whether to sort results table alphabetically (default sort is by contract size) | `false`
 | `runOnCompile` | whether to output contract sizes automatically after compilation | `false` |
-| `disambiguatePaths` | whether to output the full path to the compilation artifact (relative to the Hardhat root directory) | `false` |
+| `flat` | whether to hide the full path to the compilation artifact and output only the contract name | `false` |
 | `strict` | whether to throw an error if any contracts exceed the size limit (may cause compatibility issues with `solidity-coverage`) | `false` |
 | `only` | `Array` of `String` matchers used to select included contracts, defaults to all contracts if `length` is 0 | `[]` |
 | `except` | `Array` of `String` matchers used to exclude contracts | `[]` |
@@ -32,8 +32,8 @@ Add configuration under the `contractSizer` key:
 ```javascript
 contractSizer: {
   alphaSort: true,
-  disambiguatePaths: false,
   runOnCompile: true,
+  flat: true,
   strict: true,
   only: [':ERC20$'],
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,8 +4,8 @@ declare module 'hardhat/types/config' {
   interface HardhatUserConfig {
     contractSizer?: {
       alphaSort?: boolean,
-      disambiguatePaths?: boolean,
       runOnCompile?: boolean,
+      flat?: boolean,
       strict?: boolean,
       only?: string[],
       except?: string[],
@@ -15,8 +15,8 @@ declare module 'hardhat/types/config' {
   interface HardhatConfig {
     contractSizer: {
       alphaSort: boolean,
-      disambiguatePaths: boolean,
       runOnCompile: boolean,
+      flat: boolean,
       strict: boolean
       only: string[],
       except: string[],

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ extendConfig(function (config, userConfig) {
   config.contractSizer = Object.assign(
     {
       alphaSort: false,
-      disambiguatePaths: false,
+      flat: false,
       runOnCompile: false,
       strict: false,
       only: [],

--- a/tasks/size_contracts.js
+++ b/tasks/size_contracts.js
@@ -36,6 +36,15 @@ task(
     outputData.push({ name: fullName, size });
   }));
 
+  outputData.reduce(function (acc, { name }) {
+    if (acc.has(name)) {
+      throw new HardhatPluginError(`ambiguous contract name: ${ name }`);
+    }
+
+    acc.add(name);
+    return acc;
+  }, new Set());
+
   if (config.alphaSort) {
     outputData.sort((a, b) => a.name.toUpperCase() > b.name.toUpperCase() ? 1 : -1);
   } else {

--- a/tasks/size_contracts.js
+++ b/tasks/size_contracts.js
@@ -29,7 +29,7 @@ task(
       'hex'
     ).length;
 
-    if (!config.disambiguatePaths) {
+    if (config.flat) {
       fullName = fullName.split(':').pop();
     }
 

--- a/tasks/size_contracts.js
+++ b/tasks/size_contracts.js
@@ -61,12 +61,12 @@ task(
     });
   }));
 
-  outputData.reduce(function (acc, { name }) {
-    if (acc.has(name)) {
-      throw new HardhatPluginError(`ambiguous contract name: ${ name }`);
+  outputData.reduce(function (acc, { displayName }) {
+    if (acc.has(displayName)) {
+      throw new HardhatPluginError(`ambiguous contract name: ${ displayName }`);
     }
 
-    acc.add(name);
+    acc.add(displayName);
     return acc;
   }, new Set());
 


### PR DESCRIPTION
Breaking change, should wait for 3.0.0 SolidState release.

closes #12 