### PR TITLE
Display change from previous run

### DIFF
--- a/tasks/size_contracts.js
+++ b/tasks/size_contracts.js
@@ -53,7 +53,7 @@ task(
       fullName,
       displayName: config.disambiguatePaths ? fullName : fullName.split(':').pop(),
       size,
-      previousSize: previousSizes[fullName],
+      previousSize: previousSizes[fullName] || null,
     });
   }));
 
@@ -66,7 +66,7 @@ task(
   await fs.promises.writeFile(outputPath, JSON.stringify(outputData), { flag: 'w' });
 
   const table = new Table({
-    head: [chalk.bold('Contract Name'), chalk.bold('Size (KB)')],
+    head: [chalk.bold('Contract Name'), chalk.bold('Size (KB)'), chalk.bold('Change (KB)')],
     style: { head: [], border: [], 'padding-left': 2, 'padding-right': 2 },
     chars: {
       mid: '·',
@@ -102,9 +102,22 @@ task(
       size = chalk.yellow.bold(size);
     }
 
+
+    let diff;
+
+    if (item.size < item.previousSize) {
+      diff = chalk.green(`${ ((item.previousSize - item.size) / 1000).toFixed(3) }`);
+
+    } else if (item.size > item.previousSize) {
+      diff = chalk.red(`${ ((item.size - item.previousSize) / 1000).toFixed(3) }`);
+    } else {
+      diff = '';
+    }
+
     table.push([
       { content: item.displayName },
       { content: size, hAlign: 'right' },
+      { content: diff, hAlign: 'right' },
     ]);
   }
 

--- a/tasks/size_contracts.js
+++ b/tasks/size_contracts.js
@@ -9,6 +9,10 @@ const {
 
 const SIZE_LIMIT = 24576;
 
+const formatSize = function (size) {
+  return (size / 1000).toFixed(3);
+};
+
 task(
   'size-contracts', 'Output the size of compiled contracts'
 ).addFlag(
@@ -93,7 +97,7 @@ task(
       continue;
     }
 
-    let size = (item.size / 1000).toFixed(3);
+    let size = formatSize(item.size);
 
     if (item.size > SIZE_LIMIT) {
       size = chalk.red.bold(size);
@@ -106,10 +110,10 @@ task(
     let diff;
 
     if (item.size < item.previousSize) {
-      diff = chalk.green(((item.previousSize - item.size) / 1000).toFixed(3));
+      diff = chalk.green(formatSize(item.previousSize - item.size));
 
     } else if (item.size > item.previousSize) {
-      diff = chalk.red(((item.size - item.previousSize) / 1000).toFixed(3));
+      diff = chalk.red(formatSize(item.size - item.previousSize));
     } else {
       diff = '';
     }

--- a/tasks/size_contracts.js
+++ b/tasks/size_contracts.js
@@ -106,10 +106,10 @@ task(
     let diff;
 
     if (item.size < item.previousSize) {
-      diff = chalk.green(`${ ((item.previousSize - item.size) / 1000).toFixed(3) }`);
+      diff = chalk.green(((item.previousSize - item.size) / 1000).toFixed(3));
 
     } else if (item.size > item.previousSize) {
-      diff = chalk.red(`${ ((item.size - item.previousSize) / 1000).toFixed(3) }`);
+      diff = chalk.red(((item.size - item.previousSize) / 1000).toFixed(3));
     } else {
       diff = '';
     }

--- a/tasks/size_contracts.js
+++ b/tasks/size_contracts.js
@@ -32,15 +32,15 @@ task(
       'hex'
     ).length;
 
-    if (!config.disambiguatePaths) {
-      fullName = fullName.split(':').pop();
-    }
-
-    outputData.push({ name: fullName, size });
+    outputData.push({
+      fullName,
+      displayName: config.disambiguatePaths ? fullName : fullName.split(':').pop(),
+      size,
+    });
   }));
 
   if (config.alphaSort) {
-    outputData.sort((a, b) => a.name.toUpperCase() > b.name.toUpperCase() ? 1 : -1);
+    outputData.sort((a, b) => a.displayName.toUpperCase() > b.displayName.toUpperCase() ? 1 : -1);
   } else {
     outputData.sort((a, b) => a.size - b.size);
   }
@@ -83,7 +83,7 @@ task(
     }
 
     table.push([
-      { content: item.name },
+      { content: item.displayName },
       { content: size, hAlign: 'right' },
     ]);
   }


### PR DESCRIPTION
This change adds a new column to the output table which displays the change in contract size since the last time the `size-contracts` task was run.