### PR TITLE
feat: strip ansi and output table

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Add configuration under the `contractSizer` key:
 | `strict` | whether to throw an error if any contracts exceed the size limit (may cause compatibility issues with `solidity-coverage`) | `false` |
 | `only` | `Array` of `String` matchers used to select included contracts, defaults to all contracts if `length` is 0 | `[]` |
 | `except` | `Array` of `String` matchers used to exclude contracts | `[]` |
+| `outputFile` | file path to write contract size report | `null` |
 
 ```javascript
 contractSizer: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,7 @@ declare module 'hardhat/types/config' {
       strict?: boolean,
       only?: string[],
       except?: string[],
+      outputFile?: string,
     }
   }
 
@@ -20,6 +21,7 @@ declare module 'hardhat/types/config' {
       strict: boolean
       only: string[],
       except: string[],
+      outputFile: string
     }
   }
 }

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ extendConfig(function (config, userConfig) {
       strict: false,
       only: [],
       except: [],
+      outputFile: null,
     },
     userConfig.contractSizer
   );

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "chalk": "^4.0.0",
-    "cli-table3": "^0.6.0"
+    "cli-table3": "^0.6.0",
+    "strip-ansi": "^6.0.0"
   }
 }

--- a/tasks/size_contracts.js
+++ b/tasks/size_contracts.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const chalk = require('chalk');
+const stripAnsi = require('strip-ansi');
 const Table = require('cli-table3');
 const { HardhatPluginError } = require('hardhat/plugins');
 const {
@@ -12,23 +13,6 @@ const SIZE_LIMIT = 24576;
 const formatSize = function (size) {
   return (size / 1024).toFixed(3);
 };
-
-const ansiRegex = function ({ onlyFirst = false } = {}) {
-  const pattern = [
-    '[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]+)*|[a-zA-Z\\d]+(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)',
-    '(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-nq-uy=><~]))'
-  ].join('|');
-
-  return new RegExp(pattern, onlyFirst ? undefined : 'g');
-}
-
-const stripAnsi = function (string) {
-  if (typeof string !== 'string') {
-    throw new TypeError(`Expected a \`string\`, got \`${typeof string}\``);
-  }
-
-  return string.replace(ansiRegex(), '');
-}
 
 task(
   'size-contracts', 'Output the size of compiled contracts'

--- a/tasks/size_contracts.js
+++ b/tasks/size_contracts.js
@@ -13,6 +13,23 @@ const formatSize = function (size) {
   return (size / 1024).toFixed(3);
 };
 
+const ansiRegex = function ({ onlyFirst = false } = {}) {
+  const pattern = [
+    '[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]+)*|[a-zA-Z\\d]+(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)',
+    '(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-nq-uy=><~]))'
+  ].join('|');
+
+  return new RegExp(pattern, onlyFirst ? undefined : 'g');
+}
+
+const stripAnsi = function (string) {
+  if (typeof string !== 'string') {
+    throw new TypeError(`Expected a \`string\`, got \`${typeof string}\``);
+  }
+
+  return string.replace(ansiRegex(), '');
+}
+
 task(
   'size-contracts', 'Output the size of compiled contracts'
 ).addFlag(
@@ -151,6 +168,8 @@ task(
   }
 
   console.log(table.toString());
+  if (config.outputFile)
+    fs.writeFileSync(config.outputFile, stripAnsi(table.toString()));
 
   if (oversizedContracts > 0) {
     console.log();

--- a/tasks/size_contracts.js
+++ b/tasks/size_contracts.js
@@ -153,7 +153,7 @@ task(
 
   console.log(table.toString());
   if (config.outputFile)
-    fs.writeFileSync(config.outputFile, stripAnsi(table.toString()));
+    fs.writeFileSync(config.outputFile, `${ stripAnsi(table.toString()) }\n`);
 
   if (oversizedContracts > 0) {
     console.log();


### PR DESCRIPTION
**Feature**: Print contract sizer table to file.

Added `outputFile` similar to [eth-gas-reporter](https://github.com/cgewecke/eth-gas-reporter/blob/master/lib/gasTable.js#L260-L261) 

Considered adding `noColor` as an option but for ouput you will almost always have to strip ANSI so didn't seem like a necessary update.

Took the ANSI regex code and stripping code from [strip-ansi](https://github.com/chalk/strip-ansi)

**Why I need this:** Using Github Actions to generate Size Report that is read and commented on PRs
