### PR TITLE
Unit configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,20 +17,22 @@ yarn add --dev hardhat-contract-sizer
 Load plugin in Hardhat config:
 
 ```javascript
-require('hardhat-contract-sizer');
+require("hardhat-contract-sizer");
 ```
 
 Add configuration under the `contractSizer` key:
 
-| option | description | default |
-|-|-|-|
-| `alphaSort` | whether to sort results table alphabetically (default sort is by contract size) | `false`
-| `runOnCompile` | whether to output contract sizes automatically after compilation | `false` |
-| `disambiguatePaths` | whether to output the full path to the compilation artifact (relative to the Hardhat root directory) | `false` |
-| `strict` | whether to throw an error if any contracts exceed the size limit (may cause compatibility issues with `solidity-coverage`) | `false` |
-| `only` | `Array` of `String` matchers used to select included contracts, defaults to all contracts if `length` is 0 | `[]` |
-| `except` | `Array` of `String` matchers used to exclude contracts | `[]` |
-| `outputFile` | file path to write contract size report | `null` |
+| option              | description                                                                                                                  | default |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `alphaSort`         | whether to sort results table alphabetically (default sort is by contract size)                                              | `false` |
+| `runOnCompile`      | whether to output contract sizes automatically after compilation                                                             | `false` |
+| `disambiguatePaths` | whether to output the full path to the compilation artifact (relative to the Hardhat root directory)                         | `false` |
+| `strict`            | whether to throw an error if any contracts exceed the size limit (may cause compatibility issues with `solidity-coverage`)   | `false` |
+| `only`              | `Array` of `String` matchers used to select included contracts, defaults to all contracts if `length` is 0                   | `[]`    |
+| `except`            | `Array` of `String` matchers used to exclude contracts                                                                       | `[]`    |
+| `outputFile`        | file path to write contract size report                                                                                      | `null`  |
+| `unit`              | unit of measurement for the size of contracts, which can be expressed in 'b' (bytes), 'kib' (kibibytes), or 'kb' (kilobytes) | `kib`   |
+
 
 ```javascript
 contractSizer: {
@@ -50,7 +52,7 @@ npx hardhat size-contracts
 yarn run hardhat size-contracts
 ```
 
-By default, the hardhat `compile` task is run before sizing contracts.  This behavior can be disabled with the `--no-compile` flag:
+By default, the hardhat `compile` task is run before sizing contracts. This behavior can be disabled with the `--no-compile` flag:
 
 ```bash
 npx hardhat size-contracts --no-compile

--- a/README.md
+++ b/README.md
@@ -22,17 +22,16 @@ require("hardhat-contract-sizer");
 
 Add configuration under the `contractSizer` key:
 
-| option              | description                                                                                                                  | default |
-| ------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `alphaSort`         | whether to sort results table alphabetically (default sort is by contract size)                                              | `false` |
-| `runOnCompile`      | whether to output contract sizes automatically after compilation                                                             | `false` |
-| `disambiguatePaths` | whether to output the full path to the compilation artifact (relative to the Hardhat root directory)                         | `false` |
-| `strict`            | whether to throw an error if any contracts exceed the size limit (may cause compatibility issues with `solidity-coverage`)   | `false` |
-| `only`              | `Array` of `String` matchers used to select included contracts, defaults to all contracts if `length` is 0                   | `[]`    |
-| `except`            | `Array` of `String` matchers used to exclude contracts                                                                       | `[]`    |
-| `outputFile`        | file path to write contract size report                                                                                      | `null`  |
-| `unit`              | unit of measurement for the size of contracts, which can be expressed in 'b' (bytes), 'kib' (kibibytes), or 'kb' (kilobytes) | `kib`   |
-
+| option              | description                                                                                                                 | default |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `alphaSort`         | whether to sort results table alphabetically (default sort is by contract size)                                             | `false` |
+| `runOnCompile`      | whether to output contract sizes automatically after compilation                                                            | `false` |
+| `disambiguatePaths` | whether to output the full path to the compilation artifact (relative to the Hardhat root directory)                        | `false` |
+| `strict`            | whether to throw an error if any contracts exceed the size limit (may cause compatibility issues with `solidity-coverage`)  | `false` |
+| `only`              | `Array` of `String` matchers used to select included contracts, defaults to all contracts if `length` is 0                  | `[]`    |
+| `except`            | `Array` of `String` matchers used to exclude contracts                                                                      | `[]`    |
+| `outputFile`        | file path to write contract size report                                                                                     | `null`  |
+| `unit`              | unit of measurement for the size of contracts, which can be expressed in 'B' (bytes), 'kB' (kilobytes) or 'KiB' (kibibytes) | `KiB`   |
 
 ```javascript
 contractSizer: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,7 @@ declare module 'hardhat/types/config' {
       only?: string[],
       except?: string[],
       outputFile?: string,
+      unit?: 'b' | 'kib' | 'kb',
     }
   }
 
@@ -21,7 +22,8 @@ declare module 'hardhat/types/config' {
       strict: boolean
       only: string[],
       except: string[],
-      outputFile: string
+      outputFile: string,
+      unit: 'b' | 'kib' | 'kb',
     }
   }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,29 +1,42 @@
-import 'hardhat/types/config';
+import "hardhat/types/config";
 
-declare module 'hardhat/types/config' {
+type CaseInsensitive<T extends string> = string extends T
+  ? string
+  : T extends `${infer F1}${infer F2}${infer R}`
+  ? `${Uppercase<F1> | Lowercase<F1>}${
+      | Uppercase<F2>
+      | Lowercase<F2>}${CaseInsensitive<R>}`
+  : T extends `${infer F}${infer R}`
+  ? `${Uppercase<F> | Lowercase<F>}${CaseInsensitive<R>}`
+  : "";
+
+declare module "hardhat/types/config" {
+  type Unit = "B" | "kB" | "KiB";
+  type UnitCaseInsensitive = CaseInsensitive<Unit>;
+
   interface HardhatUserConfig {
     contractSizer?: {
-      alphaSort?: boolean,
-      disambiguatePaths?: boolean,
-      runOnCompile?: boolean,
-      strict?: boolean,
-      only?: string[],
-      except?: string[],
-      outputFile?: string,
-      unit?: 'b' | 'kib' | 'kb',
-    }
+      alphaSort?: boolean;
+      disambiguatePaths?: boolean;
+      runOnCompile?: boolean;
+      strict?: boolean;
+      only?: string[];
+      except?: string[];
+      outputFile?: string;
+      unit?: UnitCaseInsensitive;
+    };
   }
 
   interface HardhatConfig {
     contractSizer: {
-      alphaSort: boolean,
-      disambiguatePaths: boolean,
-      runOnCompile: boolean,
-      strict: boolean
-      only: string[],
-      except: string[],
-      outputFile: string,
-      unit: 'b' | 'kib' | 'kb',
-    }
+      alphaSort: boolean;
+      disambiguatePaths: boolean;
+      runOnCompile: boolean;
+      strict: boolean;
+      only: string[];
+      except: string[];
+      outputFile: string;
+      unit: UnitCaseInsensitive;
+    };
   }
 }

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ extendConfig(function (config, userConfig) {
       only: [],
       except: [],
       outputFile: null,
+      unit: 'kib',
     },
     userConfig.contractSizer
   );

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ extendConfig(function (config, userConfig) {
       only: [],
       except: [],
       outputFile: null,
-      unit: 'kib',
+      unit: 'KiB',
     },
     userConfig.contractSizer
   );

--- a/tasks/size_contracts.js
+++ b/tasks/size_contracts.js
@@ -11,7 +11,7 @@ const {
 const SIZE_LIMIT = 24576;
 
 const formatSize = function (size) {
-  return (size / 1024).toFixed(3);
+  return (size / 1000).toFixed(3);
 };
 
 task(
@@ -109,10 +109,10 @@ task(
       content: chalk.bold('Contract Name'),
     },
     {
-      content: chalk.bold('Size (KiB)'),
+      content: chalk.bold('Size (Kb)'),
     },
     {
-      content: chalk.bold('Change (KiB)'),
+      content: chalk.bold('Change (Kb)'),
     },
   ]);
 
@@ -158,7 +158,7 @@ task(
   if (oversizedContracts > 0) {
     console.log();
 
-    const message = `Warning: ${ oversizedContracts } contracts exceed the size limit for mainnet deployment (${ formatSize(SIZE_LIMIT)} KiB).`;
+    const message = `Warning: ${ oversizedContracts } contracts exceed the size limit for mainnet deployment (${ formatSize(SIZE_LIMIT)} Kb).`;
 
     if (config.strict) {
       throw new HardhatPluginError(message);

--- a/tasks/size_contracts.js
+++ b/tasks/size_contracts.js
@@ -8,12 +8,6 @@ const {
   TASK_COMPILE,
 } = require('hardhat/builtin-tasks/task-names');
 
-const SIZE_LIMIT = 24576;
-
-const formatSize = function (size) {
-  return (size / 1000).toFixed(3);
-};
-
 task(
   'size-contracts', 'Output the size of compiled contracts'
 ).addFlag(
@@ -24,6 +18,16 @@ task(
   }
 
   const config = hre.config.contractSizer;
+
+  const SIZE_LIMIT = 24576;
+  const UNITS = config.units == 'b' ? 'B' : config.units == 'kb' ? 'Kb' : 'KiB';
+
+  const formatSize = function (size) {
+    if (config.units == 'b') return size;
+    if (config.units == 'kib') return (size / 1024).toFixed(3);
+    if (config.units == 'kb') return (size / 1000).toFixed(3);
+    return (size / 1024).toFixed(3);
+  };
 
   const outputData = [];
 
@@ -94,13 +98,13 @@ task(
 
   table.push([
     {
-      content: chalk.gray(`Solc version: ${ compiler.version }`),
+      content: chalk.gray(`Solc version: ${compiler.version}`),
     },
     {
-      content: chalk.gray(`Optimizer enabled: ${ compiler.settings.optimizer.enabled }`),
+      content: chalk.gray(`Optimizer enabled: ${compiler.settings.optimizer.enabled}`),
     },
     {
-      content: chalk.gray(`Runs: ${ compiler.settings.optimizer.runs }`),
+      content: chalk.gray(`Runs: ${compiler.settings.optimizer.runs}`),
     },
   ]);
 
@@ -109,10 +113,10 @@ task(
       content: chalk.bold('Contract Name'),
     },
     {
-      content: chalk.bold('Size (Kb)'),
+      content: chalk.bold(`Size (${UNITS})`),
     },
     {
-      content: chalk.bold('Change (Kb)'),
+      content: chalk.bold(`Change (${UNITS})`),
     },
   ]);
 
@@ -136,9 +140,9 @@ task(
 
     if (item.previousSize) {
       if (item.size < item.previousSize) {
-        diff = chalk.green(`-${ formatSize(item.previousSize - item.size) }`);
+        diff = chalk.green(`-${formatSize(item.previousSize - item.size)}`);
       } else if (item.size > item.previousSize) {
-        diff = chalk.red(`+${ formatSize(item.size - item.previousSize) }`);
+        diff = chalk.red(`+${formatSize(item.size - item.previousSize)}`);
       } else {
         diff = chalk.yellow(formatSize(0));
       }
@@ -153,12 +157,12 @@ task(
 
   console.log(table.toString());
   if (config.outputFile)
-    fs.writeFileSync(config.outputFile, `${ stripAnsi(table.toString()) }\n`);
+    fs.writeFileSync(config.outputFile, `${stripAnsi(table.toString())}\n`);
 
   if (oversizedContracts > 0) {
     console.log();
 
-    const message = `Warning: ${ oversizedContracts } contracts exceed the size limit for mainnet deployment (${ formatSize(SIZE_LIMIT)} Kb).`;
+    const message = `Warning: ${oversizedContracts} contracts exceed the size limit for mainnet deployment (${formatSize(SIZE_LIMIT)} ${UNITS}).`;
 
     if (config.strict) {
       throw new HardhatPluginError(message);

--- a/tasks/size_contracts.js
+++ b/tasks/size_contracts.js
@@ -20,12 +20,11 @@ task(
   const config = hre.config.contractSizer;
 
   const SIZE_LIMIT = 24576;
-  const UNITS = config.units == 'b' ? 'B' : config.units == 'kb' ? 'Kb' : 'KiB';
+  const UNIT = config.unit.toLowerCase() === 'b' ? 'B' : config.unit.toLowerCase() === 'kb' ? 'kB' : 'KiB';
 
   const formatSize = function (size) {
-    if (config.units == 'b') return size;
-    if (config.units == 'kib') return (size / 1024).toFixed(3);
-    if (config.units == 'kb') return (size / 1000).toFixed(3);
+    if (config.unit.toLowerCase() == 'b') return size;
+    if (config.unit.toLowerCase() == 'kb') return (size / 1000).toFixed(3);
     return (size / 1024).toFixed(3);
   };
 
@@ -113,10 +112,10 @@ task(
       content: chalk.bold('Contract Name'),
     },
     {
-      content: chalk.bold(`Size (${UNITS})`),
+      content: chalk.bold(`Size (${UNIT})`),
     },
     {
-      content: chalk.bold(`Change (${UNITS})`),
+      content: chalk.bold(`Change (${UNIT})`),
     },
   ]);
 
@@ -162,7 +161,7 @@ task(
   if (oversizedContracts > 0) {
     console.log();
 
-    const message = `Warning: ${oversizedContracts} contracts exceed the size limit for mainnet deployment (${formatSize(SIZE_LIMIT)} ${UNITS}).`;
+    const message = `Warning: ${oversizedContracts} contracts exceed the size limit for mainnet deployment (${formatSize(SIZE_LIMIT)} ${UNIT}).`;
 
     if (config.strict) {
       throw new HardhatPluginError(message);


### PR DESCRIPTION
## Description
This pull request updates the unit of measurement for the contract size in the project from Kibibyte to Kilobyte. This change was made to align the unit of measurement with the official Ethereum documentation, which expresses contract size in Kilobytes:
-  [Downsizing Contracts To Fight The Contract Size Limit](https://ethereum.org/en/developers/tutorials/downsizing-contracts-to-fight-the-contract-size-limit/)
- [Hard Fork No. 4: Spurious Dragon](https://blog.ethereum.org/2016/11/18/hard-fork-no-4-spurious-dragon)

The change was made to improve console readability and ensure data compatibility with the unit of measurement used in the official documentation.

