### PR TITLE
force case-sensitive unit configuration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,19 +1,6 @@
 import "hardhat/types/config";
 
-type CaseInsensitive<T extends string> = string extends T
-  ? string
-  : T extends `${infer F1}${infer F2}${infer R}`
-  ? `${Uppercase<F1> | Lowercase<F1>}${
-      | Uppercase<F2>
-      | Lowercase<F2>}${CaseInsensitive<R>}`
-  : T extends `${infer F}${infer R}`
-  ? `${Uppercase<F> | Lowercase<F>}${CaseInsensitive<R>}`
-  : "";
-
 declare module "hardhat/types/config" {
-  type Unit = "B" | "kB" | "KiB";
-  type UnitCaseInsensitive = CaseInsensitive<Unit>;
-
   interface HardhatUserConfig {
     contractSizer?: {
       alphaSort?: boolean;
@@ -23,7 +10,7 @@ declare module "hardhat/types/config" {
       only?: string[];
       except?: string[];
       outputFile?: string;
-      unit?: UnitCaseInsensitive;
+      unit?: 'B' | 'kB' | 'KiB';
     };
   }
 
@@ -36,7 +23,7 @@ declare module "hardhat/types/config" {
       only: string[];
       except: string[];
       outputFile: string;
-      unit: UnitCaseInsensitive;
+      unit: 'B' | 'kB' | 'KiB';
     };
   }
 }

--- a/tasks/size_contracts.js
+++ b/tasks/size_contracts.js
@@ -20,12 +20,10 @@ task(
   const config = hre.config.contractSizer;
 
   const SIZE_LIMIT = 24576;
-  const UNIT = config.unit.toLowerCase() === 'b' ? 'B' : config.unit.toLowerCase() === 'kb' ? 'kB' : 'KiB';
 
   const formatSize = function (size) {
-    if (config.unit.toLowerCase() == 'b') return size;
-    if (config.unit.toLowerCase() == 'kb') return (size / 1000).toFixed(3);
-    return (size / 1024).toFixed(3);
+    const divisor = { 'B': 1, 'kB': 1000, 'KiB': 1024 }[config.unit];
+    return (size / divisor).toFixed(3);
   };
 
   const outputData = [];
@@ -112,10 +110,10 @@ task(
       content: chalk.bold('Contract Name'),
     },
     {
-      content: chalk.bold(`Size (${UNIT})`),
+      content: chalk.bold(`Size (${config.unit})`),
     },
     {
-      content: chalk.bold(`Change (${UNIT})`),
+      content: chalk.bold(`Change (${config.unit})`),
     },
   ]);
 
@@ -161,7 +159,7 @@ task(
   if (oversizedContracts > 0) {
     console.log();
 
-    const message = `Warning: ${oversizedContracts} contracts exceed the size limit for mainnet deployment (${formatSize(SIZE_LIMIT)} ${UNIT}).`;
+    const message = `Warning: ${oversizedContracts} contracts exceed the size limit for mainnet deployment (${formatSize(SIZE_LIMIT)} ${config.unit}).`;
 
     if (config.strict) {
       throw new HardhatPluginError(message);

--- a/tasks/size_contracts.js
+++ b/tasks/size_contracts.js
@@ -19,6 +19,11 @@ task(
 
   const config = hre.config.contractSizer;
 
+  // TODO: avoid hardcoding unit names
+  if (!['B', 'kB', 'KiB'].includes(config.unit)) {
+    throw new HardhatPluginError(`Invalid unit: ${ config.unit }`);
+  }
+
   const SIZE_LIMIT = 24576;
 
   const formatSize = function (size) {


### PR DESCRIPTION
This reverts a requested change made in #29.  

Could be combined with some unit conversion library to allow arbitrary inputs.  However, many library authors seem unaware of the difference between the "kilo" and "kibi" prefixes, perpetuating long-standing confusion.